### PR TITLE
(CLIENT-SIDE) Types and endpoints were aligned with openAPI

### DIFF
--- a/.changeset/grumpy-hero-tan.md
+++ b/.changeset/grumpy-hero-tan.md
@@ -713,6 +713,74 @@ Added support for following endpoint:
       - Added optional key `price`
   - Returned value:
     - Response object has changed to `ResponseValidateVoucherDiscountCode | ResponseValidateVoucherGiftCard | ResponseValidateVoucherLoyaltyCard | ResponseValidateVoucherFalse | PromotionsValidateResponse` for example:
-      - Value of key discount has been clarified
+      - Value of key `discount` has been clarified
       - Added optional keys such as `applicable_to`, `inapplicable_to` `campaign`, `reward` and `error`
 
+- client.redeem(code, payload)
+  - Request parameter `payload`: `ClientSideRedeemPayload`:
+    - Added optional key: `gift`
+    - Value of key `reward` has been clarified
+      - Added optional keys: `points` and `assignment_id`
+    - Value of key `customer` has been clarified
+      - Added optional  keys: `birthday` and `birthdate`
+    - Value of key `order` has been clarified
+      - Added optional key: `status`
+  - Returned value:
+    - Response object has changed to `RedemptionObjectDiscountVoucherExtended | RedemptionObjectLoyaltyCardExtended | RedemptionObjectGiftCardExtended` for example:
+      - Added optional keys: `channel`, `customer`, `related_object_type` and `related_object_id`
+
+- client.publish(campaign, payload, queryParams)
+  - Request parameter `payload`: `ClientSidePublishPayload`:
+    - Possible response with `CreatePublicationFromCampaign & { join_once?: boolean }` 
+    - Value of key `channel` was clarified, `'Voucherify.js' | string` -> `PublicationResponseChannel`
+    - Added optional key `campaign`
+  - Returned value:
+    - Value of key `channel` was clarified, `'Voucherify.js' | string` -> `PublicationResponseChannel`
+
+- client.listVouchers(params)
+  - Request parameter `params`: `ClientSideListVouchersParams`:
+    - Added optional key `campaign_id`
+  - Returned value:
+    - Value of key `vouchers` type object[] was clarified,
+      - Added optional keys: `id`, `campaign`, `campaign_id`, `category`, `category_id`, `categories`, `type`, `discount`, `gift`, `loyalty_card`, `validity_timeframe`, `validity_day_of_week`, `additional_info`, `is_referral_code`, `updated_at`, `holder_id`, `referrer_id`, `redemption`, `publish`,
+
+- client.createCustomer(customer, enableDoubleOptIn)
+  - Request parameter `customer`: `ClientSideCustomersCreateParams`:
+    - Added optional keys: `birthday` and `birthdate`
+  - Return value:
+    - Added optional keys: `birthday`, `birthdate`, `referrals`, `system_metadata`, `updated_at`, `assets`
+
+- client.validateStackable(params)
+  - Request (body) params:
+    - `ClientSideValidationsValidateStackableParams`:
+      - Updated `redeemables` array - has 3 options: `RedeemablesDiscountReferralPromotionTierPromotionStack`, `RedeemablesGiftCard`, `RedeemablesLoyaltyCard`
+      - Updated `order` key -  new property: `id`, optional property: `referrer`
+      - Updated `customer` key - new properties: `birthday` and `birthdate`
+  - Returned value:
+    - `ValidationValidateStackableResponse` has 2 options: `ResponseValidationsTrue` or `ResponseValidationsFalse`
+      - `ResponseValidationsTrue`:
+        - Updated default value of `valid` key: `true`
+        - Updated optional `redeemables` key - it has 5 options:
+          - `ResponseValidationsRedeemablesDiscountVoucher`,
+          - `ResponseValidationsRedeemablesGiftCard`,
+          - `ResponseValidationsRedeemablesLoyaltyCard`,
+          - `ResponseValidationsRedeemablesPromotionTier`,
+          - `ResponseValidationsRedeemablesPromotionStack`
+      - Updated optional `order` key:
+        - Removed property `id`, `created_at`,
+        - Removed optional properties: `source_id`, `updated_at`, `status`, `initial_amount`, `customer`
+        - Added optional properties: `customer_id`, `referrer_id`
+      - `ResponseValidationsFalse`:
+        - Updated default value of `valid` key: `false`
+        - Updated optional `redeemables` key - it has 5 options:
+          - `ResponseValidationsRedeemablesDiscountVoucher`,
+          - `ResponseValidationsRedeemablesGiftCard`,
+          - `ResponseValidationsRedeemablesLoyaltyCard`,
+          - `ResponseValidationsRedeemablesPromotionTier`,
+          - `ResponseValidationsRedeemablesPromotionStack`
+      - Updated optional `redeemables` key:
+        - Removed optional `order`, `applicable_to`, `inapplicable_to` key
+        - Updated optional `result` key: removed optional keys: `discount`, `gift`, `loyalty_card`
+        - Added optional `category` key (CategoryObject)
+
+- client.redeemStackable(params)

--- a/.changeset/grumpy-hero-tan.md
+++ b/.changeset/grumpy-hero-tan.md
@@ -698,8 +698,6 @@ Types of (server side) requests and responses were aligned with https://github.c
     - `ClientSideTrackResponse`:
       - Added `Record<string, any>` as a representation of returned data - `referral`, `loyalty` and `customer`.
 
-
-
 # CLIENT SIDE
 
 Added support for following endpoint:

--- a/.changeset/grumpy-hero-tan.md
+++ b/.changeset/grumpy-hero-tan.md
@@ -2,6 +2,8 @@
 '@voucherify/sdk': major
 ---
 
+# SERVER SIDE
+
 Added support for following endpoints:
   - campaigns
     - POST /campaigns/campaignId/enable
@@ -695,3 +697,22 @@ Types of (server side) requests and responses were aligned with https://github.c
   - Returned value:
     - `ClientSideTrackResponse`:
       - Added `Record<string, any>` as a representation of returned data - `referral`, `loyalty` and `customer`.
+
+
+
+# CLIENT SIDE
+
+Added support for following endpoint:
+- GET /client/promotions/tiers
+
+**TypeScript types changes:**
+
+- client.validate(params)
+  - Request parameter `params`: `ClientSideValidateParams`:
+    - Value of key `items` type object[] has been clarified:
+      - Added optional key `price`
+  - Returned value:
+    - Response object has changed to `ResponseValidateVoucherDiscountCode | ResponseValidateVoucherGiftCard | ResponseValidateVoucherLoyaltyCard | ResponseValidateVoucherFalse | PromotionsValidateResponse` for example:
+      - Value of key discount has been clarified
+      - Added optional keys such as `applicable_to`, `inapplicable_to` `campaign`, `reward` and `error`
+

--- a/.changeset/grumpy-hero-tan.md
+++ b/.changeset/grumpy-hero-tan.md
@@ -688,3 +688,10 @@ Types of (server side) requests and responses were aligned with https://github.c
       - Updated `skus` key:
         - Added optional `product_id`, `image_url` keys.
 
+- client.track(eventName, metadata, customer)
+  - Request (body) params:
+    - Updated optional property `referral` 
+      - Added optional `referrer_id` key to object.
+  - Returned value:
+    - `ClientSideTrackResponse`:
+      - Added `Record<string, any>` as a representation of returned data - `referral`, `loyalty` and `customer`.

--- a/.changeset/grumpy-hero-tan.md
+++ b/.changeset/grumpy-hero-tan.md
@@ -782,5 +782,3 @@ Added support for following endpoint:
         - Removed optional `order`, `applicable_to`, `inapplicable_to` key
         - Updated optional `result` key: removed optional keys: `discount`, `gift`, `loyalty_card`
         - Added optional `category` key (CategoryObject)
-
-- client.redeemStackable(params)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1613,7 +1613,13 @@ Methods are provided within `client.*` namespace.
 client.setIdentity(trackingId)
 ```
 
-#### [Validate](https://docs.voucherify.io/reference/vouchers-validate)
+#### [List Promotion Tiers](https://docs.voucherify.io/reference/list-promotion-tiers-client-side)
+
+```javascript
+client.listPromotionTiers(params)
+```
+
+#### [Validate](https://docs.voucherify.io/reference/validate-voucher-client-side)
 
 ```javascript
 client.validate(params)

--- a/packages/sdk/src/ClientSide.ts
+++ b/packages/sdk/src/ClientSide.ts
@@ -165,7 +165,7 @@ export class ClientSide {
 		return this.client.put<undefined>(`/customers/${encode(idOrSourceId)}/consents`, consents)
 	}
 	/**
-	 * @see https://docs.voucherify.io/reference/validate-stackable-discounts-client-side
+	 * @see https://docs.voucherify.io/reference/validate-stacked-discounts-client-side
 	 */
 	public validateStackable(params: T.ClientSideValidationsValidateStackableParams) {
 		return this.client.post<T.ClientSideValidationValidateStackableResponse>(`/validations`, params)

--- a/packages/sdk/src/ClientSide.ts
+++ b/packages/sdk/src/ClientSide.ts
@@ -1,4 +1,5 @@
 import * as T from './types/ClientSide'
+import * as PT from './types/PromotionTiers'
 
 import { assert, encode, isObject, isOptionalObject, isOptionalString, isString } from './helpers'
 
@@ -9,6 +10,12 @@ export class ClientSide {
 
 	public setIdentity(identity?: string) {
 		this.trackingId = identity
+	}
+	/**
+	 * @see https://docs.voucherify.io/reference/list-promotion-tiers-client-side
+	 */
+	public listPromotionTiers(params: PT.PromotionTiersListAllParams = {}) {
+		return this.client.get<PT.PromotionTiersListAllResponse>('/promotions/tiers', params)
 	}
 	/**
 	 * @see https://docs.voucherify.io/reference/vouchers-validate

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -111,6 +111,7 @@ export interface ClientSideTrackLoyalty {
 }
 export interface ClientSideTrackReferral {
 	code?: string
+	referrer_id?: string
 }
 
 export interface ClientSideTrackPayload {
@@ -121,10 +122,10 @@ export interface ClientSideTrackPayload {
 	referral?: ClientSideTrackReferral
 }
 
-export interface ClientSideTrackResponse {
+export type ClientSideTrackResponse = {
 	object: 'event'
 	type: string
-}
+} & Record<string, any>
 
 export interface ClientSideRedeemWidgetPayload {
 	order?: {

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -13,7 +13,7 @@ import { RedemptionsRedeemStackableParams, RedemptionsRedeemStackableResponse } 
 
 type ClientSideItem = Pick<
 	OrdersItem,
-	'source_id' | 'sku_id' | 'product_id' | 'sku' | 'quantity' | 'related_object' | 'amount'
+	'source_id' | 'sku_id' | 'product_id' | 'sku' | 'quantity' | 'related_object' | 'amount' | 'price'
 >
 
 export type ClientSideCustomersUpdateConsentsBody = CustomersUpdateConsentsBody
@@ -26,17 +26,17 @@ export interface ClientSideValidateParams {
 	code?: string
 	tracking_id?: string
 	amount?: number
+	session_key?: string
+	session_ttl?: number
+	session_ttl_unit?: 'MILLISECONDS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS'
+	metadata?: Record<string, any>
 	items?: ClientSideItem[]
 	orderMetadata?: Record<string, any>
+	session_type?: 'LOCK'
 	customer?: Pick<CustomerRequest, 'source_id' | 'metadata'>
 	reward?: {
 		id: string
 	}
-	metadata?: Record<string, any>
-	session_type?: 'LOCK'
-	session_key?: string
-	session_ttl?: number
-	session_ttl_unit?: 'MILLISECONDS' | 'SECONDS' | 'MINUTES' | 'HOURS' | 'DAYS'
 }
 
 export type ClientSideListVouchersParams = VouchersListParams

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -1,13 +1,16 @@
 import { CustomerRequest, CustomersCreateBody, CustomersCreateResponse, CustomersUpdateConsentsBody } from './Customers'
 import { VouchersListParams, VouchersResponse } from './Vouchers'
-import { DiscountAmount, DiscountPercent, DiscountUnit, DiscountFixed } from './DiscountVoucher'
 import { OrdersCreateResponse, OrdersItem } from './Orders'
-
 import { ConsentsListResponse } from './Consents'
 import { DistributionsPublicationsCreateResponse } from './Distributions'
-import { SimplePromotionTier } from './PromotionTiers'
-import { ApplicableToResultList } from './ApplicableTo'
-import { ValidationsValidateStackableParams, ValidationValidateStackableResponseClientSide } from './Validations'
+import {
+	ResponseValidateVoucherDiscountCode,
+	ResponseValidateVoucherFalse,
+	ResponseValidateVoucherGiftCard,
+	ResponseValidateVoucherLoyaltyCard,
+	ValidationsValidateStackableParams,
+	ValidationValidateStackableResponseClientSide,
+} from './Validations'
 import {
 	RedemptionsRedeemResponse,
 	RedemptionsRedeemStackableParams,
@@ -16,6 +19,7 @@ import {
 import { RewardRedemptionParams } from './Rewards'
 import { GiftRedemptionParams } from './Gift'
 import { ValidationSessionReleaseParams } from './ValidateSession'
+import { PromotionsValidateResponse } from './Promotions'
 
 type ClientSideItem = Pick<
 	OrdersItem,
@@ -57,29 +61,13 @@ export interface ClientSideListVouchersResponse {
 	data_ref: 'vouchers'
 	vouchers: ClientSideVoucherListing[]
 }
-export interface ClientSideValidateResponse {
-	code?: string
-	valid: boolean
-	discount?: DiscountUnit | DiscountAmount | DiscountPercent | DiscountFixed
-	applicable_to?: ApplicableToResultList
-	order?: {
-		amount: number
-		discount_amount: number
-		total_discount_amount: number
-		total_amount: number
-		items?: ClientSideItem[]
-	}
-	tracking_id?: string
-	campaign_id?: string
-	loyalty?: {
-		points_cost: number
-	}
-	gift?: {
-		amount: number
-		balance: number
-	}
-	promotions?: SimplePromotionTier[]
-}
+
+export type ClientSideValidateResponse =
+	| ResponseValidateVoucherDiscountCode
+	| ResponseValidateVoucherGiftCard
+	| ResponseValidateVoucherLoyaltyCard
+	| ResponseValidateVoucherFalse
+	| PromotionsValidateResponse
 
 export interface ClientSideRedeemPayload {
 	tracking_id?: string

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -1,5 +1,5 @@
 import { CustomerRequest, CustomersCreateBody, CustomersCreateResponse, CustomersUpdateConsentsBody } from './Customers'
-import { VouchersListParams, VouchersListResponse, VouchersResponse } from "./Vouchers";
+import { VouchersListParams, VouchersListResponse, VouchersResponse } from './Vouchers'
 import { OrdersCreateResponse, OrdersItem } from './Orders'
 import { ConsentsListResponse } from './Consents'
 import { DistributionsPublicationsCreateParams, DistributionsPublicationsCreateResponse } from './Distributions'

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -1,8 +1,8 @@
 import { CustomerRequest, CustomersCreateBody, CustomersCreateResponse, CustomersUpdateConsentsBody } from './Customers'
-import { VouchersListParams, VouchersResponse } from './Vouchers'
+import { VouchersListParams, VouchersListResponse, VouchersResponse } from "./Vouchers";
 import { OrdersCreateResponse, OrdersItem } from './Orders'
 import { ConsentsListResponse } from './Consents'
-import { DistributionsPublicationsCreateResponse } from './Distributions'
+import { DistributionsPublicationsCreateParams, DistributionsPublicationsCreateResponse } from './Distributions'
 import {
 	ResponseValidateVoucherDiscountCode,
 	ResponseValidateVoucherFalse,
@@ -55,12 +55,7 @@ export type ClientSideVoucherListing = Pick<
 	'active' | 'code' | 'metadata' | 'assets' | 'object' | 'expiration_date' | 'start_date' | 'created_at'
 >
 
-export interface ClientSideListVouchersResponse {
-	object: 'list'
-	total: number
-	data_ref: 'vouchers'
-	vouchers: ClientSideVoucherListing[]
-}
+export type ClientSideListVouchersResponse = VouchersListResponse
 
 export type ClientSideValidateResponse =
 	| ResponseValidateVoucherDiscountCode
@@ -85,13 +80,7 @@ export type ClientSideRedeemOrder = Partial<Pick<OrdersCreateResponse, 'id' | 's
 
 export type ClientSideRedeemResponse = RedemptionsRedeemResponse
 
-export interface ClientSidePublishPayload {
-	source_id?: string
-	channel?: 'Voucherify.js' | string
-	customer?: CustomerRequest
-	voucher?: string
-	metadata?: Record<string, any>
-}
+export type ClientSidePublishPayload = DistributionsPublicationsCreateParams
 
 export type ClientSidePublishPreparedPayload = ClientSidePublishPayload
 
@@ -105,7 +94,7 @@ export interface ClientSidePublishCampaign {
 	count?: number
 }
 
-export type ClientSidePublishResponse = DistributionsPublicationsCreateResponse & { vouchers_id?: string[] }
+export type ClientSidePublishResponse = DistributionsPublicationsCreateResponse
 export interface ClientSideTrackLoyalty {
 	code?: string
 }

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -6,10 +6,16 @@ import { OrdersCreateResponse, OrdersItem } from './Orders'
 import { ConsentsListResponse } from './Consents'
 import { DistributionsPublicationsCreateResponse } from './Distributions'
 import { SimplePromotionTier } from './PromotionTiers'
-import { ValidationSessionReleaseParams } from './ValidateSession'
 import { ApplicableToResultList } from './ApplicableTo'
 import { ValidationsValidateStackableParams, ValidationValidateStackableResponseClientSide } from './Validations'
-import { RedemptionsRedeemStackableParams, RedemptionsRedeemStackableResponse } from './Redemptions'
+import {
+	RedemptionsRedeemResponse,
+	RedemptionsRedeemStackableParams,
+	RedemptionsRedeemStackableResponse,
+} from './Redemptions'
+import { RewardRedemptionParams } from './Rewards'
+import { GiftRedemptionParams } from './Gift'
+import { ValidationSessionReleaseParams } from './ValidateSession'
 
 type ClientSideItem = Pick<
 	OrdersItem,
@@ -78,25 +84,18 @@ export interface ClientSideValidateResponse {
 export interface ClientSideRedeemPayload {
 	tracking_id?: string
 	customer?: CustomerRequest
-	order?: ClientSideRedeemOrder
+	order?: Pick<Partial<OrdersCreateResponse>, 'id' | 'source_id' | 'amount' | 'items' | 'status' | 'metadata'>
 	metadata?: Record<string, any>
-	reward?: {
-		id: string
-	}
+	reward?: RewardRedemptionParams
+	gift?: GiftRedemptionParams
 	session?: ValidationSessionReleaseParams
 }
 
-export interface ClientSideRedeemResponse {
-	id: string
-	object: 'redemption'
-	date?: string
-	customer_id?: string
-	tracking_id?: string
-	order?: OrdersCreateResponse
-	metadata?: Record<string, any>
-	result: 'SUCCESS' | 'FAILURE'
-	voucher?: VouchersResponse
+export type ClientSideRedeemOrder = Partial<Pick<OrdersCreateResponse, 'id' | 'source_id' | 'metadata' | 'amount'>> & {
+	items?: ClientSideItem[]
 }
+
+export type ClientSideRedeemResponse = RedemptionsRedeemResponse
 
 export interface ClientSidePublishPayload {
 	source_id?: string
@@ -137,10 +136,6 @@ export interface ClientSideTrackPayload {
 export interface ClientSideTrackResponse {
 	object: 'event'
 	type: string
-}
-
-export type ClientSideRedeemOrder = Partial<Pick<OrdersCreateResponse, 'id' | 'source_id' | 'metadata' | 'amount'>> & {
-	items?: ClientSideItem[]
 }
 
 export interface ClientSideRedeemWidgetPayload {

--- a/packages/sdk/src/types/Distributions.ts
+++ b/packages/sdk/src/types/Distributions.ts
@@ -30,6 +30,7 @@ export type PublicationResponseChannel =
 	| 'SMS'
 	| 'voucherify-website'
 	| 'Webhook'
+	| 'Voucherify.js' //hard-coded channel from V% js SDK
 
 export type DistributionsPublicationsVoucher =
 	| DistributionsPublicationsVoucherDiscount

--- a/packages/sdk/src/types/Validations.ts
+++ b/packages/sdk/src/types/Validations.ts
@@ -57,7 +57,7 @@ export interface ResponseValidateVoucherFalse {
 	metadata?: Record<string, any>
 }
 
-interface ResponseValidateVoucherLoyaltyCard {
+export interface ResponseValidateVoucherLoyaltyCard {
 	valid: boolean
 	applicable_to: ApplicableToObjectPromotionTier //6_res_applicable_to_object
 	inapplicable_to: InapplicableToObjectPromotionTier //6_res_inapplicable_to_object
@@ -80,7 +80,7 @@ interface ResponseValidateVoucherLoyaltyCard {
 	session: ValidationSessionParams
 }
 
-interface ResponseValidateVoucherGiftCard {
+export interface ResponseValidateVoucherGiftCard {
 	valid: boolean
 	applicable_to: ApplicableToObjectPromotionTier //6_res_applicable_to_object
 	inapplicable_to: InapplicableToObjectPromotionTier //6_res_inapplicable_to_object
@@ -100,7 +100,7 @@ interface ResponseValidateVoucherGiftCard {
 	session: ValidationSessionParams
 }
 
-interface ResponseValidateVoucherDiscountCode {
+export interface ResponseValidateVoucherDiscountCode {
 	valid: boolean
 	applicable_to: ApplicableToObjectPromotionTier //6_res_applicable_to_object
 	inapplicable_to: InapplicableToObjectPromotionTier //6_res_inapplicable_to_object

--- a/packages/sdk/src/types/Vouchers.ts
+++ b/packages/sdk/src/types/Vouchers.ts
@@ -431,11 +431,22 @@ export interface VouchersListParams {
 		after?: string
 		before?: string
 	}
-	order?: '-created_at' | 'created_at' | '-updated_at' | 'updated_at' | '-code' | 'code'
+	order?:
+		| '-created_at'
+		| 'created_at'
+		| '-updated_at'
+		| 'updated_at'
+		| '-type'
+		| 'type'
+		| '-code'
+		| 'code'
+		| '-campaign'
+		| 'campaign'
+		| '-category'
+		| 'category'
 	filters?: {
 		junction?: string
-		[filter_condition: string]: any
-	}
+	} & Record<string, any>
 }
 
 export interface VouchersListResponse {

--- a/packages/sdk/src/types/Vouchers.ts
+++ b/packages/sdk/src/types/Vouchers.ts
@@ -443,7 +443,7 @@ export interface VouchersListResponse {
 	object: 'list'
 	total: number
 	data_ref: 'vouchers'
-	vouchers: Omit<VouchersResponse[], 'validation_rules_assignments'>
+	vouchers: Omit<VouchersResponse, 'validation_rules_assignments'>[]
 }
 
 export type VouchersEnableResponse = VouchersResponse


### PR DESCRIPTION
# CLIENT SIDE

Added support for following endpoint:
- GET /client/promotions/tiers

**TypeScript types changes:**

- client.validate(params)
  - Request parameter `params`: `ClientSideValidateParams`:
    - Value of key `items` type object[] has been clarified:
      - Added optional key `price`
  - Returned value:
    - Response object has changed to `ResponseValidateVoucherDiscountCode | ResponseValidateVoucherGiftCard | ResponseValidateVoucherLoyaltyCard | ResponseValidateVoucherFalse | PromotionsValidateResponse` for example:
      - Value of key `discount` has been clarified
      - Added optional keys such as `applicable_to`, `inapplicable_to` `campaign`, `reward` and `error`

- client.redeem(code, payload)
  - Request parameter `payload`: `ClientSideRedeemPayload`:
    - Added optional key: `gift`
    - Value of key `reward` has been clarified
      - Added optional keys: `points` and `assignment_id`
    - Value of key `customer` has been clarified
      - Added optional  keys: `birthday` and `birthdate`
    - Value of key `order` has been clarified
      - Added optional key: `status`
  - Returned value:
    - Response object has changed to `RedemptionObjectDiscountVoucherExtended | RedemptionObjectLoyaltyCardExtended | RedemptionObjectGiftCardExtended` for example:
      - Added optional keys: `channel`, `customer`, `related_object_type` and `related_object_id`

- client.publish(campaign, payload, queryParams)
  - Request parameter `payload`: `ClientSidePublishPayload`:
    - Possible response with `CreatePublicationFromCampaign & { join_once?: boolean }` 
    - Value of key `channel` was clarified, `'Voucherify.js' | string` -> `PublicationResponseChannel`
    - Added optional key `campaign`
  - Returned value:
    - Value of key `channel` was clarified, `'Voucherify.js' | string` -> `PublicationResponseChannel`

- client.listVouchers(params)
  - Request parameter `params`: `ClientSideListVouchersParams`:
    - Added optional key `campaign_id`
  - Returned value:
    - Value of key `vouchers` type object[] was clarified,
      - Added optional keys: `id`, `campaign`, `campaign_id`, `category`, `category_id`, `categories`, `type`, `discount`, `gift`, `loyalty_card`, `validity_timeframe`, `validity_day_of_week`, `additional_info`, `is_referral_code`, `updated_at`, `holder_id`, `referrer_id`, `redemption`, `publish`,

- client.createCustomer(customer, enableDoubleOptIn)
  - Request parameter `customer`: `ClientSideCustomersCreateParams`:
    - Added optional keys: `birthday` and `birthdate`
  - Return value:
    - Added optional keys: `birthday`, `birthdate`, `referrals`, `system_metadata`, `updated_at`, `assets`

- client.validateStackable(params)
  - Request (body) params:
    - `ClientSideValidationsValidateStackableParams`:
      - Updated `redeemables` array - has 3 options: `RedeemablesDiscountReferralPromotionTierPromotionStack`, `RedeemablesGiftCard`, `RedeemablesLoyaltyCard`
      - Updated `order` key -  new property: `id`, optional property: `referrer`
      - Updated `customer` key - new properties: `birthday` and `birthdate`
  - Returned value:
    - `ValidationValidateStackableResponse` has 2 options: `ResponseValidationsTrue` or `ResponseValidationsFalse`
      - `ResponseValidationsTrue`:
        - Updated default value of `valid` key: `true`
        - Updated optional `redeemables` key - it has 5 options:
          - `ResponseValidationsRedeemablesDiscountVoucher`,
          - `ResponseValidationsRedeemablesGiftCard`,
          - `ResponseValidationsRedeemablesLoyaltyCard`,
          - `ResponseValidationsRedeemablesPromotionTier`,
          - `ResponseValidationsRedeemablesPromotionStack`
      - Updated optional `order` key:
        - Removed property `id`, `created_at`,
        - Removed optional properties: `source_id`, `updated_at`, `status`, `initial_amount`, `customer`
        - Added optional properties: `customer_id`, `referrer_id`
      - `ResponseValidationsFalse`:
        - Updated default value of `valid` key: `false`
        - Updated optional `redeemables` key - it has 5 options:
          - `ResponseValidationsRedeemablesDiscountVoucher`,
          - `ResponseValidationsRedeemablesGiftCard`,
          - `ResponseValidationsRedeemablesLoyaltyCard`,
          - `ResponseValidationsRedeemablesPromotionTier`,
          - `ResponseValidationsRedeemablesPromotionStack`
      - Updated optional `redeemables` key:
        - Removed optional `order`, `applicable_to`, `inapplicable_to` key
        - Updated optional `result` key: removed optional keys: `discount`, `gift`, `loyalty_card`
        - Added optional `category` key (CategoryObject)
