### PR TITLE
Pz/types 006 - LoyaltyRewardAssignment (MAJOR)

### DIFF
--- a/.changeset/tidy-comics-ironman.md
+++ b/.changeset/tidy-comics-ironman.md
@@ -2,48 +2,11 @@
 '@voucherify/sdk': major
 ---
 
-#### Added support for following endpoints:
-- loyalties
-  - GET /loyalties/{campaignId}/rewards/{assignmentId}
-    - method: `client.loyalties.getRewardAssignment(campaignId, assignmentId)`
-  - GET `/loyalties/${campaignId}/tiers/{tierId}/rewards`
-    - method: `client.loyalties.listLoyaltyTierReward(campaignId, tierId)`
-
-#### New exported types/interfaces
-- Loyalties.ts
-  - ListLoyaltyTierRewardResponse
-  - LoyaltyTierRewardObject
-  - LoyaltyTierRewardRewardObject
-  - LoyaltyTierRewardRewardObjectCommon
-  - LoyaltyTierRewardRewardCampaignObject
-  - LoyaltyTierRewardRewardCoinObject
-  - LoyaltyTierRewardRewardMaterialObject
-  - RewardParametersCampaign
-  - RewardParametersCoin
-  - RewardParametersProduct
-  - GetRewardAssignmentsResponse
-- Rewards.ts
-  - RewardsAssignmentObjectCommon
-
-#### Breaking changes in types/interfaces
-- RewardsAssignmentObject
-  - related_object_id - required
-  - related_object_type - required, value always: `campaign`
-  - parameters - required
-    - loyalty - required
-      - points - not required
-  - updated_at - required `string` or `null`
-- RewardsCreateAssignment
-  - campaign - required
-  - parameters - required
-    - loyalty - required
-      - points - not required
-- RewardsCreateAssignmentResponse
-  - updated_at - required, value always: `null`
-- RewardsUpdateAssignmentResponse
-  - updated_at - required, value always: `string`
-
-#### Note
-- RewardsCreateAssignment
-  - This type was defined incorrectly, if you have tried before to `createAssignment` without parameters as they were not required, you would fail every time. So change in types shall not hurt you if your script already worked properly.
-
+Added support for new endpoints and adding missing types in rewards api.
+- Added support for new endpoints: `/loyalties/{campaignId}/rewards/{assignmentId}` and `/loyalties/${campaignId}/tiers/{tierId}/rewards` [(example available in readme.md)](..%2F..%2Fpackages%2Fsdk%2FREADME.md)
+- New exported types/interfaces in `Loyalties.ts`: `ListLoyaltyTierRewardResponse`, `LoyaltyTierRewardObject`, `LoyaltyTierRewardRewardObject`, `LoyaltyTierRewardRewardObjectCommon`, `LoyaltyTierRewardRewardCampaignObject`, `LoyaltyTierRewardRewardCoinObject`, `LoyaltyTierRewardRewardMaterialObject`, `RewardParametersCampaign`, `RewardParametersCoin`, `RewardParametersProduct` and `GetRewardAssignmentsResponse`
+- New exported types/interfaces in `Rewards.ts`: `RewardsAssignmentObjectCommon`
+- **(BREAKING CHANGE)** Interface `RewardsAssignmentObject` was changed. Few values are now required, uses union type.
+- **(BREAKING CHANGE)** Interface `RewardsCreateAssignment` was changed. Few values are now required. **If previously you send data without required parameters, you failed anyway.**
+- **(BREAKING CHANGE)** Interface `RewardsCreateAssignmentResponse` was changed. Type of value `updated_at` is always `null`.
+- **(BREAKING CHANGE)** Interface `RewardsUpdateAssignmentResponse` was changed. Type of value `updated_at` is always `string`.

--- a/.changeset/tidy-comics-ironman.md
+++ b/.changeset/tidy-comics-ironman.md
@@ -1,0 +1,44 @@
+---
+'@voucherify/sdk': major
+---
+
+To run tests you need to copy packages/sdk/.env.example to packages/sdk/.env and fill the file with your credentials.
+Tests uses REAL calls to Voucherify. You may reach the limit of your account if you are using sandbox account.
+
+**New exported types/interfaces**
+- Loyalties.ts
+  - ListLoyaltyTierRewardResponse
+  - LoyaltyTierRewardObject
+  - LoyaltyTierRewardRewardObject
+  - LoyaltyTierRewardRewardObjectCommon
+  - LoyaltyTierRewardRewardCampaignObject
+  - LoyaltyTierRewardRewardCoinObject
+  - LoyaltyTierRewardRewardMaterialObject
+  - RewardParametersCampaign
+  - RewardParametersCoin
+  - RewardParametersProduct
+- Rewards.ts
+  - RewardsAssignmentObjectCommon
+
+**Breaking changes in types/interfaces**
+- RewardsAssignmentObject
+  - related_object_id - required
+  - related_object_type - required, value always: `campaign`
+  - parameters - required
+    - loyalty - required
+      - points - not required
+  - updated_at - required `string` or `null`
+- RewardsCreateAssignment
+  - campaign - required
+  - parameters - required
+    - loyalty - required
+      - points - not required
+- RewardsCreateAssignmentResponse
+  - updated_at - required, value always: `null`
+- RewardsUpdateAssignmentResponse
+  - updated_at - required, value always: `string`
+
+**Note**
+- RewardsCreateAssignment
+  - This type was defined incorrectly, if you have tried before to `createAssignment` without parameters as they were not required, you would fail every time. So change in types shall not hurt you if your script already worked properly.
+

--- a/.changeset/tidy-comics-ironman.md
+++ b/.changeset/tidy-comics-ironman.md
@@ -5,6 +5,12 @@
 To run tests you need to copy packages/sdk/.env.example to packages/sdk/.env and fill the file with your credentials.
 Tests uses REAL calls to Voucherify. You may reach the limit of your account if you are using sandbox account.
 
+**New methods**
+```js
+client.loyalties.getRewardAssignment(campaignId, assignmentId)
+client.loyalties.listLoyaltyTierReward(campaignId, tierId)
+```
+
 **New exported types/interfaces**
 - Loyalties.ts
   - ListLoyaltyTierRewardResponse
@@ -17,6 +23,7 @@ Tests uses REAL calls to Voucherify. You may reach the limit of your account if 
   - RewardParametersCampaign
   - RewardParametersCoin
   - RewardParametersProduct
+  - GetRewardAssignmentsResponse
 - Rewards.ts
   - RewardsAssignmentObjectCommon
 

--- a/.changeset/tidy-comics-ironman.md
+++ b/.changeset/tidy-comics-ironman.md
@@ -2,16 +2,14 @@
 '@voucherify/sdk': major
 ---
 
-To run tests you need to copy packages/sdk/.env.example to packages/sdk/.env and fill the file with your credentials.
-Tests uses REAL calls to Voucherify. You may reach the limit of your account if you are using sandbox account.
+#### Added support for following endpoints:
+- loyalties
+  - GET /loyalties/{campaignId}/rewards/{assignmentId}
+    - method: `client.loyalties.getRewardAssignment(campaignId, assignmentId)`
+  - GET `/loyalties/${campaignId}/tiers/{tierId}/rewards`
+    - method: `client.loyalties.listLoyaltyTierReward(campaignId, tierId)`
 
-**New methods**
-```js
-client.loyalties.getRewardAssignment(campaignId, assignmentId)
-client.loyalties.listLoyaltyTierReward(campaignId, tierId)
-```
-
-**New exported types/interfaces**
+#### New exported types/interfaces
 - Loyalties.ts
   - ListLoyaltyTierRewardResponse
   - LoyaltyTierRewardObject
@@ -27,7 +25,7 @@ client.loyalties.listLoyaltyTierReward(campaignId, tierId)
 - Rewards.ts
   - RewardsAssignmentObjectCommon
 
-**Breaking changes in types/interfaces**
+#### Breaking changes in types/interfaces
 - RewardsAssignmentObject
   - related_object_id - required
   - related_object_type - required, value always: `campaign`
@@ -45,7 +43,7 @@ client.loyalties.listLoyaltyTierReward(campaignId, tierId)
 - RewardsUpdateAssignmentResponse
   - updated_at - required, value always: `string`
 
-**Note**
+#### Note
 - RewardsCreateAssignment
   - This type was defined incorrectly, if you have tried before to `createAssignment` without parameters as they were not required, you would fail every time. So change in types shall not hurt you if your script already worked properly.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -870,6 +870,7 @@ Methods are provided within `client.loyalties.*` namespace.
 - [Create Loyalty Program Reward Assignment](#create-loyalty-program-reward-assignment)
 - [Update Loyalty Program Reward Assignment](#update-loyalty-program-reward-assignment)
 - [Delete Loyalty Program Reward Assignment](#delete-loyalty-program-reward-assignment)
+- [Get Loyalty Program Reward Assignment](#get-loyalty-program-reward-assignment)
 - [List Loyalty Program Reward Assignments](#list-loyalty-program-reward-assignments)
 - [Create Loyalty Program Earning Rules](#create-loyalty-program-earning-rules)
 - [Update Loyalty Program Earning Rule](#update-loyalty-program-earning-rule)
@@ -930,6 +931,12 @@ client.loyalties.updateRewardAssignment(campaignId, assignment)
 
 ```javascript
 client.loyalties.deleteRewardAssignment(campaignId, assignmentId)
+```
+
+#### [Get Loyalty Program Reward Assignment](https://docs.voucherify.io/reference/get-reward-assignment-1)
+
+```javascript
+client.loyalties.getRewardAssignment(campaignId, assignmentId)
 ```
 
 #### [List Loyalty Program Reward Assignments](https://docs.voucherify.io/reference/list-reward-assignments-1)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -881,6 +881,7 @@ Methods are provided within `client.loyalties.*` namespace.
 - [Get Loyalty Program Member Activities](#get-loyalty-program-member-activities)
 - [Add Loyalty Card Balance](#add-loyalty-card-balance)
 - [Redeem Loyalty Card](#redeem-loyalty-card)
+- [List Loyalty Tier Rewards](#list-loyalty-tier-rewards)
 
 #### [Create Loyalty Program](https://docs.voucherify.io/reference/create-loyalty-program)
 
@@ -1009,6 +1010,12 @@ client.loyalties.redeemReward(campaignId, memberId, params)
 When redeeming reward with type `COIN` you need to provide additional `order` object in the `params`
 
 ---
+
+#### [List Loyalty Tier Rewards](https://docs.voucherify.io/reference/list-loyalty-tier-rewards)
+
+```javascript
+client.loyalties.listLoyaltyTierReward(campaignId, tierId)
+```
 
 ### Segments
 

--- a/packages/sdk/src/Loyalties.ts
+++ b/packages/sdk/src/Loyalties.ts
@@ -70,6 +70,14 @@ export class Loyalties {
 		return this.client.delete(`/loyalties/${encode(campaignId)}/rewards/${assignmentId}`)
 	}
 	/**
+	 * @see https://docs.voucherify.io/reference/get-reward-assignment-1
+	 */
+	public getRewardAssignment(campaignId: string, assignmentId: string) {
+		return this.client.get<T.GetRewardAssignmentsResponse>(
+			`/loyalties/${encode(campaignId)}/rewards/${encode(assignmentId)}`,
+		)
+	}
+	/**
 	 * @see https://docs.voucherify.io/reference/list-earning-rules
 	 */
 	public listEarningRules(campaignId: string, params: T.LoyaltiesListEarningRulesParams = {}) {

--- a/packages/sdk/src/Loyalties.ts
+++ b/packages/sdk/src/Loyalties.ts
@@ -158,6 +158,8 @@ export class Loyalties {
 	 * @see https://docs.voucherify.io/reference/list-loyalty-tier-rewards
 	 */
 	public listLoyaltyTierReward(campaignId: string, tierId: string) {
-		return this.client.get<T.ListLoyaltyTierRewardResponse>(`/loyalties/${encode(campaignId)}/tiers/${tierId}/rewards`)
+		return this.client.get<T.ListLoyaltyTierRewardResponse>(
+			`/loyalties/${encode(campaignId)}/tiers/${encode(tierId)}/rewards`,
+		)
 	}
 }

--- a/packages/sdk/src/Loyalties.ts
+++ b/packages/sdk/src/Loyalties.ts
@@ -146,4 +146,10 @@ export class Loyalties {
 			params,
 		)
 	}
+	/**
+	 * @see https://docs.voucherify.io/reference/list-loyalty-tier-rewards
+	 */
+	public listLoyaltyTierReward(campaignId: string, tierId: string) {
+		return this.client.get<T.ListLoyaltyTierRewardResponse>(`/loyalties/${encode(campaignId)}/tiers/${tierId}/rewards`)
+	}
 }

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -519,6 +519,7 @@ export interface LoyaltyTierRewardRewardObjectCommon {
 	id: string
 	name: string | null
 	redeemed: number | null
+	stock: number | null
 	attributes?: {
 		image_url?: string
 		description?: string

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -512,15 +512,6 @@ export interface LoyaltyTierRewardObject {
 	object: 'loyalty_tier_reward'
 }
 
-export interface RewardsCreateAssignment {
-	campaign: string
-	parameters: {
-		loyalty: {
-			points?: number
-		}
-	}
-}
-
 export type LoyaltyTierRewardRewardObject = LoyaltyTierRewardObjectCommon &
 	(LoyaltyTierRewardRewardCampaignObject | LoyaltyTierRewardRewardCoinObject | LoyaltyTierRewardRewardMaterialObject)
 

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -4,6 +4,7 @@ import { ProductsCreateResponse, ProductsCreateSkuResponse } from './Products'
 import { SimpleCustomer } from './Customers'
 import { ValidationRulesCreateAssignmentResponse } from './ValidationRules'
 import { VouchersResponse } from './Vouchers'
+import { RewardsAssignmentObject } from './Rewards'
 
 interface LoyaltiesVoucher {
 	code_config?: {
@@ -496,4 +497,100 @@ export interface LoyaltiesRedeemRewardResponse {
 export interface LoyaltyPointsTransfer {
 	code: string
 	points: number
+}
+
+export interface ListLoyaltyTierRewardResponse {
+	object: 'list'
+	data_ref: 'data'
+	data: LoyaltyTierRewardObject[]
+	total: number
+}
+
+export interface LoyaltyTierRewardObject {
+	reward: LoyaltyTierRewardRewardObject
+	assignment: RewardsAssignmentObject
+	object: 'loyalty_tier_reward'
+}
+
+export interface RewardAssignmentObjectCommon {
+	id: string
+	reward_id: string
+	related_object_id: string
+	related_object_type: 'campaign'
+	parameters: {
+		loyalty: {
+			points?: number
+		}
+	}
+	created_at: string
+	object: 'reward_assignment'
+}
+
+export interface RewardAssignmentObject extends RewardAssignmentObjectCommon {
+	updated_at: string | null
+}
+
+export type RewardsCreateAssignmentResponse = RewardAssignmentObjectCommon & { updated_at: null }
+
+export interface RewardsCreateAssignment {
+	campaign: string
+	parameters: {
+		loyalty: {
+			points?: number
+		}
+	}
+}
+
+export type LoyaltyTierRewardRewardObject = LoyaltyTierRewardObjectCommon &
+	(LoyaltyTierRewardRewardCampaignObject | LoyaltyTierRewardRewardCoinObject | LoyaltyTierRewardRewardMaterialObject)
+
+export interface LoyaltyTierRewardObjectCommon {
+	id: string
+	name: string | null
+	redeemed: number | null
+	attributes?: {
+		image_url?: string
+		description?: string
+	}
+	created_at: string
+	updated_at: string | null
+	metadata: Record<string, any>
+	object: 'reward'
+}
+
+export interface LoyaltyTierRewardRewardCampaignObject {
+	type: 'CAMPAIGN'
+	parameters: {
+		campaign: RewardParametersCampaign
+	}
+}
+
+export interface LoyaltyTierRewardRewardCoinObject {
+	type: 'COIN'
+	parameters: {
+		coin: RewardParametersCoin
+	}
+}
+
+export interface LoyaltyTierRewardRewardMaterialObject {
+	type: 'MATERIAL'
+	parameters: {
+		product: RewardParametersProduct
+	}
+}
+
+export interface RewardParametersCampaign {
+	id: string
+	balance?: number
+	type: string
+}
+
+export interface RewardParametersCoin {
+	exchange_ratio: number
+	points_ratio: number
+}
+
+export interface RewardParametersProduct {
+	id?: string
+	sku_id?: string
 }

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -512,26 +512,6 @@ export interface LoyaltyTierRewardObject {
 	object: 'loyalty_tier_reward'
 }
 
-export interface RewardAssignmentObjectCommon {
-	id: string
-	reward_id: string
-	related_object_id: string
-	related_object_type: 'campaign'
-	parameters: {
-		loyalty: {
-			points?: number
-		}
-	}
-	created_at: string
-	object: 'reward_assignment'
-}
-
-export interface RewardAssignmentObject extends RewardAssignmentObjectCommon {
-	updated_at: string | null
-}
-
-export type RewardsCreateAssignmentResponse = RewardAssignmentObjectCommon & { updated_at: null }
-
 export interface RewardsCreateAssignment {
 	campaign: string
 	parameters: {

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -512,10 +512,10 @@ export interface LoyaltyTierRewardObject {
 	object: 'loyalty_tier_reward'
 }
 
-export type LoyaltyTierRewardRewardObject = LoyaltyTierRewardObjectCommon &
+export type LoyaltyTierRewardRewardObject = LoyaltyTierRewardRewardObjectCommon &
 	(LoyaltyTierRewardRewardCampaignObject | LoyaltyTierRewardRewardCoinObject | LoyaltyTierRewardRewardMaterialObject)
 
-export interface LoyaltyTierRewardObjectCommon {
+export interface LoyaltyTierRewardRewardObjectCommon {
 	id: string
 	name: string | null
 	redeemed: number | null

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -499,6 +499,8 @@ export interface LoyaltyPointsTransfer {
 	points: number
 }
 
+export type GetRewardAssignmentsResponse = RewardsAssignmentObject
+
 export interface ListLoyaltyTierRewardResponse {
 	object: 'list'
 	data_ref: 'data'

--- a/packages/sdk/src/types/Rewards.ts
+++ b/packages/sdk/src/types/Rewards.ts
@@ -131,7 +131,7 @@ export interface RewardsCreateAssignment {
 
 export type RewardsCreateAssignmentResponse = RewardsAssignmentObjectCommon & { updated_at: null }
 
-export type RewardsUpdateAssignment = RewardsCreateAssignment & { id: string }
+export type RewardsUpdateAssignment = Partial<RewardsCreateAssignment> & { id: string }
 
 export type RewardsUpdateAssignmentResponse = RewardsAssignmentObjectCommon & { updated_at: string }
 

--- a/packages/sdk/src/types/Rewards.ts
+++ b/packages/sdk/src/types/Rewards.ts
@@ -1,5 +1,3 @@
-import { RewardAssignmentObjectCommon } from './Loyalties'
-
 export interface RewardsListParams {
 	page?: number
 	limit?: number
@@ -131,11 +129,11 @@ export interface RewardsCreateAssignment {
 	}
 }
 
-export type RewardsCreateAssignmentResponse = RewardAssignmentObjectCommon & { updated_at: null }
+export type RewardsCreateAssignmentResponse = RewardsAssignmentObjectCommon & { updated_at: null }
 
 export type RewardsUpdateAssignment = RewardsCreateAssignment & { id: string }
 
-export type RewardsUpdateAssignmentResponse = RewardAssignmentObjectCommon & { updated_at: string }
+export type RewardsUpdateAssignmentResponse = RewardsAssignmentObjectCommon & { updated_at: string }
 
 export interface RewardRedemptionParams {
 	points?: number

--- a/packages/sdk/src/types/Rewards.ts
+++ b/packages/sdk/src/types/Rewards.ts
@@ -1,3 +1,5 @@
+import { RewardAssignmentObjectCommon } from './Loyalties'
+
 export interface RewardsListParams {
 	page?: number
 	limit?: number
@@ -90,19 +92,22 @@ export type RewardsUpdate = Omit<RewardsCreate, 'type'> & { id: string }
 
 export type RewardsUpdateResponse = RewardsCreateResponse
 
-export interface RewardsAssignmentObject {
+export interface RewardsAssignmentObjectCommon {
 	id: string
 	reward_id: string
-	related_object_id?: string
-	related_object_type?: string
-	parameters?: {
-		loyalty?: {
-			points: number
+	related_object_id: string
+	related_object_type: 'campaign'
+	parameters: {
+		loyalty: {
+			points?: number
 		}
 	}
 	created_at: string
-	updated_at?: string
 	object: 'reward_assignment'
+}
+
+export interface RewardsAssignmentObject extends RewardsAssignmentObjectCommon {
+	updated_at: string | null
 }
 
 export interface RewardsListAssignmentsParams {
@@ -118,19 +123,19 @@ export interface RewardsListAssignmentsResponse {
 }
 
 export interface RewardsCreateAssignment {
-	campaign?: string
-	parameters?: {
-		loyalty?: {
-			points: number
+	campaign: string
+	parameters: {
+		loyalty: {
+			points?: number
 		}
 	}
 }
 
-export type RewardsCreateAssignmentResponse = RewardsAssignmentObject
+export type RewardsCreateAssignmentResponse = RewardAssignmentObjectCommon & { updated_at: null }
 
 export type RewardsUpdateAssignment = RewardsCreateAssignment & { id: string }
 
-export type RewardsUpdateAssignmentResponse = RewardsAssignmentObject
+export type RewardsUpdateAssignmentResponse = RewardAssignmentObjectCommon & { updated_at: string }
 
 export interface RewardRedemptionParams {
 	points?: number


### PR DESCRIPTION
---
'@voucherify/sdk': major
---

To run tests you need to copy packages/sdk/.env.example to packages/sdk/.env and fill the file with your credentials.
Tests uses REAL calls to Voucherify. You may reach the limit of your account if you are using sandbox account.

**New methods**
```js
client.loyalties.getRewardAssignment(campaignId, assignmentId)
client.loyalties.listLoyaltyTierReward(campaignId, tierId)
```

**New exported types/interfaces**
- Loyalties.ts
  - ListLoyaltyTierRewardResponse
  - LoyaltyTierRewardObject
  - LoyaltyTierRewardRewardObject
  - LoyaltyTierRewardRewardObjectCommon
  - LoyaltyTierRewardRewardCampaignObject
  - LoyaltyTierRewardRewardCoinObject
  - LoyaltyTierRewardRewardMaterialObject
  - RewardParametersCampaign
  - RewardParametersCoin
  - RewardParametersProduct
  - GetRewardAssignmentsResponse
- Rewards.ts
  - RewardsAssignmentObjectCommon

**Breaking changes in types/interfaces**
- RewardsAssignmentObject
  - related_object_id - required
  - related_object_type - required, value always: `campaign`
  - parameters - required
    - loyalty - required
      - points - not required
  - updated_at - required `string` or `null`
- RewardsCreateAssignment
  - campaign - required
  - parameters - required
    - loyalty - required
      - points - not required
- RewardsCreateAssignmentResponse
  - updated_at - required, value always: `null`
- RewardsUpdateAssignmentResponse
  - updated_at - required, value always: `string`

**Note**
- RewardsCreateAssignment
  - This type was defined incorrectly, if you have tried before to `createAssignment` without parameters as they were not required, you would fail every time. So change in types shall not hurt you if your script already worked properly.

